### PR TITLE
chore: fix train-test splitting

### DIFF
--- a/decision_tree.ipynb
+++ b/decision_tree.ipynb
@@ -293,7 +293,7 @@
    },
    "outputs": [],
    "source": [
-    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, random_state=70)"
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, random_state=70, stratify=y)"
    ]
   },
   {
@@ -523,7 +523,7 @@
    },
    "outputs": [],
    "source": [
-    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, random_state=60)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, random_state=60, stratify=y)\n",
     "\n",
     "dtree = DecisionTreeClassifier()\n",
     "dtree.fit(X_train, y_train)\n",
@@ -576,9 +576,9 @@
    },
    "outputs": [],
    "source": [
-    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, random_state=42)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, random_state=42, stratify=y)\n",
     "\n",
-    "X_train, X_dev, y_train, y_dev = train_test_split(X_train, y_train, test_size=0.10, random_state=42)\n",
+    "X_train, X_dev, y_train, y_dev = train_test_split(X_train, y_train, test_size=0.10, random_state=42, stratify=y_train)\n",
     "\n",
     "# F-strings https://realpython.com/python-f-strings/\n",
     "print(f\"Training size: {len(X_train)}, Validation size: {len(X_dev)}, Test size: {len(X_test)}\")"
@@ -792,7 +792,7 @@
    },
    "outputs": [],
    "source": [
-    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=100)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=100, stratify=y)\n",
     "\n",
     "rf = RandomForestClassifier(n_jobs=-1)  # parallelize the execution\n",
     "rf.fit(X_train, y_train)"


### PR DESCRIPTION
This commits changes the train-test splitting in the decision tree example to use stratification.