### PR TITLE
feat(lab-7): replace ngrok tunnel with Colab built-in port proxy

### DIFF
--- a/mlops.ipynb
+++ b/mlops.ipynb
@@ -26,7 +26,15 @@
    "cell_type": "markdown",
    "id": "780ebf978238",
    "metadata": {},
-   "source": "# MLOps: Full Lifecycle with MLflow\n\n> **Goal:** Experience the complete MLOps lifecycle \u2014 data extraction, preprocessing, model training with experiment tracking, model registry, inference, drift detection, and REST serving \u2014 using a real Spotify tracks dataset and MLflow.\n\n> **Requirements:** A free [ngrok account](https://dashboard.ngrok.com/signup) for the MLflow UI. All other dependencies are installed in the first cell.\n\n> **Important:** Run cells top-to-bottom in a single Colab session. Variables set in earlier sections are used by later ones."
+   "source": [
+    "# MLOps: Full Lifecycle with MLflow\n",
+    "\n",
+    "> **Goal:** Experience the complete MLOps lifecycle — data extraction, preprocessing, model training with experiment tracking, model registry, inference, drift detection, and REST serving — using a real Spotify tracks dataset and MLflow.\n",
+    "\n",
+    "> **Requirements:** All dependencies are installed in the first cell. No external accounts needed.\n",
+    "\n",
+    "> **Important:** Run cells top-to-bottom in a single Colab session. Variables set in earlier sections are used by later ones.\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -46,7 +54,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%pip install mlflow==2.22.0 scikit-learn==1.8.0 polars==1.30.0 evidently==0.7.5 pyngrok==7.2.2 numpy==2.4.4 pandas==3.0.2 flask==3.1.0 requests==2.32.3 matplotlib --quiet"
+   "source": "%pip install mlflow==2.22.0 scikit-learn==1.8.0 polars==1.30.0 evidently==0.7.5 numpy==2.4.4 pandas==3.0.2 flask==3.1.0 requests==2.32.3 matplotlib --quiet"
   },
   {
    "cell_type": "markdown",
@@ -66,7 +74,7 @@
    "cell_type": "markdown",
    "id": "fc54d24547c7",
    "metadata": {},
-   "source": "### 0.3 Start MLflow Server\n\nMLflow needs a **SQLite backend** (not just a file store) to support the Model Registry feature we use in Section 5. We start it as a background process and poll until it responds.\n\n> **Why SQLite?** MLflow's Model Registry (versioning, aliases) requires a database. SQLite is built into Python \u2014 no extra installation needed."
+   "source": "### 0.3 Start MLflow Server\n\nMLflow needs a **SQLite backend** (not just a file store) to support the Model Registry feature we use in Section 5. We start it as a background process and poll until it responds.\n\n> **Why SQLite?** MLflow's Model Registry (versioning, aliases) requires a database. SQLite is built into Python — no extra installation needed."
   },
   {
    "cell_type": "code",
@@ -74,13 +82,19 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import subprocess\nimport time\nimport requests as req\n\nmlflow_process = subprocess.Popen(\n    [\"mlflow\", \"server\",\n     \"--backend-store-uri\", \"sqlite:///mlflow.db\",\n     \"--default-artifact-root\", str(BASE_DIR / \"mlruns\"),\n     \"--host\", \"0.0.0.0\",\n     \"--port\", \"5000\"],\n    stdout=subprocess.DEVNULL,\n    stderr=subprocess.DEVNULL,\n)\n\n# Poll until server responds (MLflow root / returns 200 when ready)\nfor i in range(20):\n    try:\n        r = req.get(\"http://localhost:5000/\", timeout=2)\n        if r.status_code == 200:\n            print(f\"MLflow server ready after {(i+1)*2}s\")\n            break\n    except Exception:\n        pass\n    time.sleep(2)\nelse:\n    raise RuntimeError(\"MLflow server did not start in time \u2014 check the process\")"
+   "source": "import subprocess\nimport time\nimport requests as req\n\nmlflow_process = subprocess.Popen(\n    [\"mlflow\", \"server\",\n     \"--backend-store-uri\", \"sqlite:///mlflow.db\",\n     \"--default-artifact-root\", str(BASE_DIR / \"mlruns\"),\n     \"--host\", \"0.0.0.0\",\n     \"--port\", \"5000\"],\n    stdout=subprocess.DEVNULL,\n    stderr=subprocess.DEVNULL,\n)\n\n# Poll until server responds (MLflow root / returns 200 when ready)\nfor i in range(20):\n    try:\n        r = req.get(\"http://localhost:5000/\", timeout=2)\n        if r.status_code == 200:\n            print(f\"MLflow server ready after {(i+1)*2}s\")\n            break\n    except Exception:\n        pass\n    time.sleep(2)\nelse:\n    raise RuntimeError(\"MLflow server did not start in time — check the process\")"
   },
   {
    "cell_type": "markdown",
    "id": "c029eb67ba89",
    "metadata": {},
-   "source": "### 0.4 Expose MLflow UI via ngrok\n\n**You need a free ngrok account for this step.**\n\n1. Go to https://dashboard.ngrok.com/signup and create a free account\n2. Copy your authtoken from https://dashboard.ngrok.com/get-started/your-authtoken\n3. Paste it in the cell below\n\nThis gives you a public URL to access the MLflow UI from your browser."
+   "source": [
+    "### 0.4 Get MLflow UI URL\n",
+    "\n",
+    "Colab's built-in port proxy gives you a public URL for any local port — no account or token needed. The cell below generates a URL for the MLflow server we started in 0.3.\n",
+    "\n",
+    "If you're running this notebook locally (not in Colab), it falls back to `http://localhost:5000`.\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -88,7 +102,16 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from pyngrok import ngrok\n\n# Paste your ngrok authtoken here:\nNGROK_TOKEN = \"YOUR_TOKEN_HERE\"\n\nngrok.set_auth_token(NGROK_TOKEN)\ntunnel = ngrok.connect(5000)\nMLFLOW_PUBLIC_URL = tunnel.public_url  # extract clean URL string\nprint(f\"MLflow UI: {MLFLOW_PUBLIC_URL}\")\nprint(\"Open this URL in a new tab \u2014 you should see an empty MLflow Experiments page.\")"
+   "source": [
+    "try:\n",
+    "    from google.colab.output import eval_js\n",
+    "    MLFLOW_PUBLIC_URL = eval_js(\"google.colab.kernel.proxyPort(5000)\")\n",
+    "except ImportError:\n",
+    "    MLFLOW_PUBLIC_URL = \"http://localhost:5000\"\n",
+    "\n",
+    "print(f\"MLflow UI: {MLFLOW_PUBLIC_URL}\")\n",
+    "print(\"Open this URL in a new tab — you should see an empty MLflow Experiments page.\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -114,7 +137,7 @@
    "cell_type": "markdown",
    "id": "4294e503947d",
    "metadata": {},
-   "source": "### Why Data Extraction is a Distinct Step\n\nIn production ML pipelines, data extraction is always separated from preprocessing:\n- **Auditability**: you can always reprocess from the raw source\n- **Reproducibility**: the raw file is immutable; every transform is tracked\n- **Data lake pattern**: raw data lands in one place, processed data in another\n\nHere we load from our bundled CSV (committed to the repo), mimicking a read from a data lake.\n\n**Polars `scan_csv` vs `read_csv`:** `scan_csv()` returns a `LazyFrame` \u2014 data is NOT loaded into memory yet. Operations you chain on it are recorded as a query plan. Only `.collect()` executes the plan. For our 5K-row dataset the difference is small, but the pattern scales well."
+   "source": "### Why Data Extraction is a Distinct Step\n\nIn production ML pipelines, data extraction is always separated from preprocessing:\n- **Auditability**: you can always reprocess from the raw source\n- **Reproducibility**: the raw file is immutable; every transform is tracked\n- **Data lake pattern**: raw data lands in one place, processed data in another\n\nHere we load from our bundled CSV (committed to the repo), mimicking a read from a data lake.\n\n**Polars `scan_csv` vs `read_csv`:** `scan_csv()` returns a `LazyFrame` — data is NOT loaded into memory yet. Operations you chain on it are recorded as a query plan. Only `.collect()` executes the plan. For our 5K-row dataset the difference is small, but the pattern scales well."
   },
   {
    "cell_type": "code",
@@ -142,7 +165,7 @@
    "cell_type": "markdown",
    "id": "fda0714b423e",
    "metadata": {},
-   "source": "### Why EDA Before Preprocessing\n\nBefore writing a single transform, we need to understand:\n- Is `popularity` (our target) normally distributed or skewed?\n- Which features correlate with popularity?\n- Are features on very different scales? (Hint: yes \u2014 `loudness` is in dB, `duration_ms` is in milliseconds)\n- How balanced is the genre distribution? (Dataset has 6 genres, balanced at ~900 tracks each)\n\nThese observations directly inform our preprocessing choices."
+   "source": "### Why EDA Before Preprocessing\n\nBefore writing a single transform, we need to understand:\n- Is `popularity` (our target) normally distributed or skewed?\n- Which features correlate with popularity?\n- Are features on very different scales? (Hint: yes — `loudness` is in dB, `duration_ms` is in milliseconds)\n- How balanced is the genre distribution? (Dataset has 6 genres, balanced at ~900 tracks each)\n\nThese observations directly inform our preprocessing choices."
   },
   {
    "cell_type": "code",
@@ -174,7 +197,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Feature scale comparison \u2014 this is why we normalize\nprint(\"Feature ranges (note the very different scales):\")\nprint(eda_df[[\"loudness\", \"duration_ms\", \"tempo\", \"danceability\"]].describe().round(2))\nprint()\nprint(eda_df.describe().round(2))"
+   "source": "# Feature scale comparison — this is why we normalize\nprint(\"Feature ranges (note the very different scales):\")\nprint(eda_df[[\"loudness\", \"duration_ms\", \"tempo\", \"danceability\"]].describe().round(2))\nprint()\nprint(eda_df.describe().round(2))"
   },
   {
    "cell_type": "markdown",
@@ -186,7 +209,7 @@
    "cell_type": "markdown",
    "id": "bdf7307e0680",
    "metadata": {},
-   "source": "### Preprocessing Pipeline\n\nPreprocessing transforms raw data into model-ready features. The same transformations **must** be applied consistently at both training and inference time \u2014 inconsistency here is one of the most common bugs in production ML.\n\nWe use Polars' lazy API to chain all transforms, then `.collect()` once to execute.\n\n**One-hot vs ordinal encoding for genre:** Genre is a **nominal** categorical variable \u2014 there is no inherent order between pop, rock, and hip-hop. We use one-hot encoding (one binary column per genre, drop-first) rather than ordinal encoding (which would imply a false numerical ordering). Tree-based models handle many binary features well."
+   "source": "### Preprocessing Pipeline\n\nPreprocessing transforms raw data into model-ready features. The same transformations **must** be applied consistently at both training and inference time — inconsistency here is one of the most common bugs in production ML.\n\nWe use Polars' lazy API to chain all transforms, then `.collect()` once to execute.\n\n**One-hot vs ordinal encoding for genre:** Genre is a **nominal** categorical variable — there is no inherent order between pop, rock, and hip-hop. We use one-hot encoding (one binary column per genre, drop-first) rather than ordinal encoding (which would imply a false numerical ordering). Tree-based models handle many binary features well."
   },
   {
    "cell_type": "code",
@@ -216,7 +239,7 @@
    "cell_type": "markdown",
    "id": "b5ead365ff99",
    "metadata": {},
-   "source": "**Preprocessing artifacts stored as notebook variables for use in later sections:**\n- `LOUDNESS_MIN`, `LOUDNESS_MAX` \u2014 for normalising new loudness values at inference time\n- `DURATION_MIN`, `DURATION_MAX` \u2014 for normalising new duration values at inference time\n- `GENRE_COLUMNS` \u2014 the ordered list of one-hot column names (must match exactly at inference)\n- `preprocessed_df` \u2014 the pandas DataFrame used as Evidently reference in Section 6"
+   "source": "**Preprocessing artifacts stored as notebook variables for use in later sections:**\n- `LOUDNESS_MIN`, `LOUDNESS_MAX` — for normalising new loudness values at inference time\n- `DURATION_MIN`, `DURATION_MAX` — for normalising new duration values at inference time\n- `GENRE_COLUMNS` — the ordered list of one-hot column names (must match exactly at inference)\n- `preprocessed_df` — the pandas DataFrame used as Evidently reference in Section 6"
   },
   {
    "cell_type": "markdown",
@@ -228,7 +251,7 @@
    "cell_type": "markdown",
    "id": "953897de64f0",
    "metadata": {},
-   "source": "### Config-Driven Feature Selection\n\nIn production, feature lists and split parameters live in config files \u2014 not hardcoded in training scripts. This means swapping features is a config change, not a code change.\n\n> **Note:** `GENRE_COLUMNS` was set in Section 2. This section must run in the same kernel session as Section 2."
+   "source": "### Config-Driven Feature Selection\n\nIn production, feature lists and split parameters live in config files — not hardcoded in training scripts. This means swapping features is a config change, not a code change.\n\n> **Note:** `GENRE_COLUMNS` was set in Section 2. This section must run in the same kernel session as Section 2."
   },
   {
    "cell_type": "code",
@@ -242,7 +265,7 @@
    "cell_type": "markdown",
    "id": "e80344a84924",
    "metadata": {},
-   "source": "### Train/Test Split\n\nWe convert to pandas here \u2014 scikit-learn requires pandas DataFrames or numpy arrays, not Polars. The conversion happens at this **boundary** between our data pipeline (Polars) and our ML pipeline (sklearn)."
+   "source": "### Train/Test Split\n\nWe convert to pandas here — scikit-learn requires pandas DataFrames or numpy arrays, not Polars. The conversion happens at this **boundary** between our data pipeline (Polars) and our ML pipeline (sklearn)."
   },
   {
    "cell_type": "code",
@@ -270,7 +293,7 @@
    "cell_type": "markdown",
    "id": "ec2ae629c5f1",
    "metadata": {},
-   "source": "### Experiment Tracking with MLflow\n\nWithout tracking, ML experiments are invisible: \"which model did I train? what params? what was the accuracy?\" MLflow solves this by logging everything \u2014 params, metrics, data snapshots, and the model artifact \u2014 to a persistent store you can query and compare.\n\nAll three models run in a **single experiment** (`spotify-popularity`) so you can compare them side-by-side in the UI. Grids are intentionally smaller than production for classroom timing (~5 minutes total on Colab free tier)."
+   "source": "### Experiment Tracking with MLflow\n\nWithout tracking, ML experiments are invisible: \"which model did I train? what params? what was the accuracy?\" MLflow solves this by logging everything — params, metrics, data snapshots, and the model artifact — to a persistent store you can query and compare.\n\nAll three models run in a **single experiment** (`spotify-popularity`) so you can compare them side-by-side in the UI. Grids are intentionally smaller than production for classroom timing (~5 minutes total on Colab free tier)."
   },
   {
    "cell_type": "code",
@@ -278,7 +301,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import mlflow\nimport mlflow.sklearn\nimport numpy as np\nimport pandas as pd\nfrom sklearn.linear_model import LinearRegression\nfrom sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor\nfrom sklearn.model_selection import GridSearchCV\nfrom sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score\n\nmlflow.set_experiment(\"spotify-popularity\")\n\nMODELS = {\n    \"LinearRegression\": {\n        \"class\": LinearRegression,\n        \"params\": {\"fit_intercept\": [True, False]},\n        \"n_jobs\": None,\n    },\n    \"RandomForestRegressor\": {\n        \"class\": RandomForestRegressor,\n        \"params\": {\n            \"n_estimators\": [50, 100],\n            \"max_depth\": [5, 10],\n            \"min_samples_split\": [2, 5],\n        },\n        \"n_jobs\": -1,\n    },\n    \"GradientBoostingRegressor\": {\n        \"class\": GradientBoostingRegressor,\n        \"params\": {\n            \"n_estimators\": [100, 200],\n            \"learning_rate\": [0.05, 0.1],\n            \"max_depth\": [3, 5],\n        },\n        \"n_jobs\": None,  # GB is sequential \u2014 n_jobs has no effect\n    },\n}\n\nprint(\"Models to train:\", list(MODELS.keys()))\nprint(\"\\nGrid sizes (intentionally reduced from production for class timing):\")\nfor name, cfg in MODELS.items():\n    n = 1\n    for v in cfg[\"params\"].values():\n        n *= len(v)\n    print(f\"  {name}: {n} combos x 5 folds = {n*5} fits\")"
+   "source": "import mlflow\nimport mlflow.sklearn\nimport numpy as np\nimport pandas as pd\nfrom sklearn.linear_model import LinearRegression\nfrom sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor\nfrom sklearn.model_selection import GridSearchCV\nfrom sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score\n\nmlflow.set_experiment(\"spotify-popularity\")\n\nMODELS = {\n    \"LinearRegression\": {\n        \"class\": LinearRegression,\n        \"params\": {\"fit_intercept\": [True, False]},\n        \"n_jobs\": None,\n    },\n    \"RandomForestRegressor\": {\n        \"class\": RandomForestRegressor,\n        \"params\": {\n            \"n_estimators\": [50, 100],\n            \"max_depth\": [5, 10],\n            \"min_samples_split\": [2, 5],\n        },\n        \"n_jobs\": -1,\n    },\n    \"GradientBoostingRegressor\": {\n        \"class\": GradientBoostingRegressor,\n        \"params\": {\n            \"n_estimators\": [100, 200],\n            \"learning_rate\": [0.05, 0.1],\n            \"max_depth\": [3, 5],\n        },\n        \"n_jobs\": None,  # GB is sequential — n_jobs has no effect\n    },\n}\n\nprint(\"Models to train:\", list(MODELS.keys()))\nprint(\"\\nGrid sizes (intentionally reduced from production for class timing):\")\nfor name, cfg in MODELS.items():\n    n = 1\n    for v in cfg[\"params\"].values():\n        n *= len(v)\n    print(f\"  {name}: {n} combos x 5 folds = {n*5} fits\")"
   },
   {
    "cell_type": "code",
@@ -286,7 +309,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "results = []\nbest_run_id = None\nbest_r2 = -np.inf\nbest_model_name = None\n\nfor model_name, model_cfg in MODELS.items():\n    print(f\"\\nTraining {model_name}...\")\n\n    estimator = model_cfg[\"class\"]()\n    grid_search = GridSearchCV(\n        estimator,\n        model_cfg[\"params\"],\n        cv=5,\n        scoring=\"neg_mean_squared_error\",\n        n_jobs=model_cfg[\"n_jobs\"],\n        verbose=0,\n    )\n\n    with mlflow.start_run(run_name=model_name) as run:\n        grid_search.fit(X_train, y_train)\n        best_estimator = grid_search.best_estimator_\n\n        y_pred = best_estimator.predict(X_test)\n        rmse = np.sqrt(mean_squared_error(y_test, y_pred))\n        mae = mean_absolute_error(y_test, y_pred)\n        r2 = r2_score(y_test, y_pred)\n\n        mlflow.log_params(grid_search.best_params_)\n        mlflow.log_metrics({\"rmse\": rmse, \"mae\": mae, \"r2\": r2})\n\n        # Log grid search results CSV as artifact\n        cv_path = f\"/tmp/{model_name}_cv_results.csv\"\n        pd.DataFrame(grid_search.cv_results_).to_csv(cv_path, index=False)\n        mlflow.log_artifact(cv_path, \"grid_search\")\n\n        # Log model artifact only (NOT registered here \u2014 registration happens in Section 5)\n        input_example = X_train.head(5)\n        signature = mlflow.models.infer_signature(X_train, y_pred)\n        mlflow.sklearn.log_model(\n            best_estimator,\n            artifact_path=\"model\",\n            signature=signature,\n            input_example=input_example,\n        )\n\n        run_id = run.info.run_id\n\n    results.append({\"model\": model_name, \"rmse\": rmse, \"mae\": mae, \"r2\": r2, \"run_id\": run_id})\n\n    if r2 > best_r2:\n        best_r2 = r2\n        best_run_id = run_id\n        best_model_name = model_name\n\n    print(f\"  RMSE={rmse:.3f}  MAE={mae:.3f}  R2={r2:.3f}\")\n\nprint(f\"\\nBest model: {best_model_name} (R2={best_r2:.3f})\")\nprint(f\"Best run ID: {best_run_id}\")"
+   "source": "results = []\nbest_run_id = None\nbest_r2 = -np.inf\nbest_model_name = None\n\nfor model_name, model_cfg in MODELS.items():\n    print(f\"\\nTraining {model_name}...\")\n\n    estimator = model_cfg[\"class\"]()\n    grid_search = GridSearchCV(\n        estimator,\n        model_cfg[\"params\"],\n        cv=5,\n        scoring=\"neg_mean_squared_error\",\n        n_jobs=model_cfg[\"n_jobs\"],\n        verbose=0,\n    )\n\n    with mlflow.start_run(run_name=model_name) as run:\n        grid_search.fit(X_train, y_train)\n        best_estimator = grid_search.best_estimator_\n\n        y_pred = best_estimator.predict(X_test)\n        rmse = np.sqrt(mean_squared_error(y_test, y_pred))\n        mae = mean_absolute_error(y_test, y_pred)\n        r2 = r2_score(y_test, y_pred)\n\n        mlflow.log_params(grid_search.best_params_)\n        mlflow.log_metrics({\"rmse\": rmse, \"mae\": mae, \"r2\": r2})\n\n        # Log grid search results CSV as artifact\n        cv_path = f\"/tmp/{model_name}_cv_results.csv\"\n        pd.DataFrame(grid_search.cv_results_).to_csv(cv_path, index=False)\n        mlflow.log_artifact(cv_path, \"grid_search\")\n\n        # Log model artifact only (NOT registered here — registration happens in Section 5)\n        input_example = X_train.head(5)\n        signature = mlflow.models.infer_signature(X_train, y_pred)\n        mlflow.sklearn.log_model(\n            best_estimator,\n            artifact_path=\"model\",\n            signature=signature,\n            input_example=input_example,\n        )\n\n        run_id = run.info.run_id\n\n    results.append({\"model\": model_name, \"rmse\": rmse, \"mae\": mae, \"r2\": r2, \"run_id\": run_id})\n\n    if r2 > best_r2:\n        best_r2 = r2\n        best_run_id = run_id\n        best_model_name = model_name\n\n    print(f\"  RMSE={rmse:.3f}  MAE={mae:.3f}  R2={r2:.3f}\")\n\nprint(f\"\\nBest model: {best_model_name} (R2={best_r2:.3f})\")\nprint(f\"Best run ID: {best_run_id}\")"
   },
   {
    "cell_type": "code",
@@ -300,7 +323,7 @@
    "cell_type": "markdown",
    "id": "3b9de5a0a273",
    "metadata": {},
-   "source": "### What to do in the MLflow UI\n\n1. Open the URL printed in Section 0.4\n2. Click the **spotify-popularity** experiment in the left sidebar\n3. Select all 3 runs and click **Compare**\n4. Check the **Metrics** tab \u2014 which model has the lowest RMSE and highest R2?\n5. Check the **Parameters** tab to see the best hyperparameters per model\n6. Click any run to see its artifacts (model files, grid search CSV)"
+   "source": "### What to do in the MLflow UI\n\n1. Open the URL printed in Section 0.4\n2. Click the **spotify-popularity** experiment in the left sidebar\n3. Select all 3 runs and click **Compare**\n4. Check the **Metrics** tab — which model has the lowest RMSE and highest R2?\n5. Check the **Parameters** tab to see the best hyperparameters per model\n6. Click any run to see its artifacts (model files, grid search CSV)"
   },
   {
    "cell_type": "markdown",
@@ -334,7 +357,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "client = MlflowClient()\n\n# Set the \"production\" alias \u2014 this is the modern MLflow 2.x pattern\nclient.set_registered_model_alias(\n    name=REGISTRY_MODEL_NAME,\n    alias=\"production\",\n    version=mv.version,\n)\nprint(f\"Set alias 'production' -> version {mv.version}\")"
+   "source": "client = MlflowClient()\n\n# Set the \"production\" alias — this is the modern MLflow 2.x pattern\nclient.set_registered_model_alias(\n    name=REGISTRY_MODEL_NAME,\n    alias=\"production\",\n    version=mv.version,\n)\nprint(f\"Set alias 'production' -> version {mv.version}\")"
   },
   {
    "cell_type": "code",
@@ -368,7 +391,7 @@
    "cell_type": "markdown",
    "id": "1f1b72b3f875",
    "metadata": {},
-   "source": "### Data Drift: Why Models Degrade\n\nA model trained today may perform poorly next month \u2014 not because the model is wrong, but because the **input data distribution changed**. User listening habits shift, the data pipeline introduces noise, new genres emerge.\n\n**Distribution shift**: the statistical distribution of features changes.\n**Concept drift**: the relationship between features and the target changes.\n\nWe use [Evidently](https://docs.evidentlyai.com/) to detect distribution shift by running statistical tests per feature (Kolmogorov-Smirnov for numeric features)."
+   "source": "### Data Drift: Why Models Degrade\n\nA model trained today may perform poorly next month — not because the model is wrong, but because the **input data distribution changed**. User listening habits shift, the data pipeline introduces noise, new genres emerge.\n\n**Distribution shift**: the statistical distribution of features changes.\n**Concept drift**: the relationship between features and the target changes.\n\nWe use [Evidently](https://docs.evidentlyai.com/) to detect distribution shift by running statistical tests per feature (Kolmogorov-Smirnov for numeric features)."
   },
   {
    "cell_type": "code",
@@ -410,7 +433,7 @@
    "cell_type": "markdown",
    "id": "1799f05baae6",
    "metadata": {},
-   "source": "### Model Serving: From Notebook to API\n\nIn production, models are rarely called directly from Python \u2014 they're served as REST APIs so any system (web apps, mobile apps, data pipelines) can request predictions over HTTP.\n\nWe create a minimal Flask endpoint that wraps `model.predict()`. We use an **in-process daemon thread** rather than `mlflow models serve` (which creates a separate virtualenv \u2014 slow and complex for Colab).\n\n> The Flask server runs on the same Colab VM, so we reach it via `localhost` \u2014 no second ngrok tunnel needed. Free ngrok accounts allow only one tunnel."
+   "source": "### Model Serving: From Notebook to API\n\nIn production, models are rarely called directly from Python — they're served as REST APIs so any system (web apps, mobile apps, data pipelines) can request predictions over HTTP.\n\nWe create a minimal Flask endpoint that wraps `model.predict()`. We use an **in-process daemon thread** rather than `mlflow models serve` (which creates a separate virtualenv — slow and complex for Colab).\n\n> The Flask server runs on the same Colab VM, so we reach it via `localhost`."
   },
   {
    "cell_type": "code",
@@ -440,7 +463,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "sample = X_test.iloc[[0]].to_dict(orient=\"records\")\n\nresponse = requests.post(\n    \"http://localhost:7072/predict\",\n    json={\"instances\": sample},\n    headers={\"Content-Type\": \"application/json\"},\n)\n\nprint(f\"Status: {response.status_code}\")\nprint(f\"Response: {response.json()}\")\nprint(f\"\\nDirect model prediction: {model.predict(X_test.iloc[[0]])[0]:.2f}\")\nprint(f\"API prediction:          {response.json()['predictions'][0]:.2f}\")\nprint(\"(Should be identical \u2014 the API wraps the same model.predict() call)\")"
+   "source": "sample = X_test.iloc[[0]].to_dict(orient=\"records\")\n\nresponse = requests.post(\n    \"http://localhost:7072/predict\",\n    json={\"instances\": sample},\n    headers={\"Content-Type\": \"application/json\"},\n)\n\nprint(f\"Status: {response.status_code}\")\nprint(f\"Response: {response.json()}\")\nprint(f\"\\nDirect model prediction: {model.predict(X_test.iloc[[0]])[0]:.2f}\")\nprint(f\"API prediction:          {response.json()['predictions'][0]:.2f}\")\nprint(\"(Should be identical — the API wraps the same model.predict() call)\")"
   },
   {
    "cell_type": "markdown",
@@ -460,7 +483,7 @@
    "cell_type": "markdown",
    "id": "1d9b23676208",
    "metadata": {},
-   "source": "### How This Works in Production\n\nIn a real deployment, this Flask pattern would be replaced by:\n- **MLflow Serving**: `mlflow models serve -m \"models:/spotify-popularity-model@production\" --port 7072`\n- **FastAPI + Docker**: containerised service behind a load balancer\n- **Cloud endpoints**: Azure ML, AWS SageMaker, Google Vertex AI\n\nThe key insight: the model is loaded from the **registry** (not a file path), and deploying a new version = updating the `\"production\"` alias \u2014 without changing application code."
+   "source": "### How This Works in Production\n\nIn a real deployment, this Flask pattern would be replaced by:\n- **MLflow Serving**: `mlflow models serve -m \"models:/spotify-popularity-model@production\" --port 7072`\n- **FastAPI + Docker**: containerised service behind a load balancer\n- **Cloud endpoints**: Azure ML, AWS SageMaker, Google Vertex AI\n\nThe key insight: the model is loaded from the **registry** (not a file path), and deploying a new version = updating the `\"production\"` alias — without changing application code."
   }
  ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ lab-7 = [
   "numpy==2.4.4",
   "pandas==3.0.2",
   "polars==1.30.0",
-  "pyngrok==7.2.2",
   "requests==2.32.3",
   "scikit-learn==1.8.0",
 ]


### PR DESCRIPTION
Replaces the pyngrok-based ngrok tunnel in Section 0.4 of mlops.ipynb with Colab's built-in kernel port proxy (`google.colab.kernel.proxyPort(5000)`). Students no longer need to create a third-party account or paste an authtoken before accessing the MLflow UI — the proxy URL is generated automatically and authenticated through their existing Google session. A try/except ImportError fallback to localhost:5000 preserves local (non-Colab) usability. The pyngrok dependency is removed from both the notebook's pip install cell and the lab-7 extras group in pyproject.toml.