### PR TITLE
fix(lab-7): upgrade deps for mlflow 3.12.0 and fix Colab compatibility

### DIFF
--- a/mlops.ipynb
+++ b/mlops.ipynb
@@ -54,7 +54,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%pip install mlflow==2.22.0 scikit-learn==1.8.0 polars==1.30.0 evidently==0.7.5 numpy==2.4.4 pandas==3.0.2 flask==3.1.0 requests==2.32.3 matplotlib --quiet"
+   "source": [
+    "%pip install mlflow==3.12.0 scikit-learn==1.8.0 polars==1.40.1 evidently==0.7.21 numpy==2.4.4 pandas==2.3.3 flask==3.1.3 requests==2.33.1 matplotlib==3.10.9 --quiet\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -82,7 +84,36 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import subprocess\nimport time\nimport requests as req\n\nmlflow_process = subprocess.Popen(\n    [\"mlflow\", \"server\",\n     \"--backend-store-uri\", \"sqlite:///mlflow.db\",\n     \"--default-artifact-root\", str(BASE_DIR / \"mlruns\"),\n     \"--host\", \"0.0.0.0\",\n     \"--port\", \"5000\"],\n    stdout=subprocess.DEVNULL,\n    stderr=subprocess.DEVNULL,\n)\n\n# Poll until server responds (MLflow root / returns 200 when ready)\nfor i in range(20):\n    try:\n        r = req.get(\"http://localhost:5000/\", timeout=2)\n        if r.status_code == 200:\n            print(f\"MLflow server ready after {(i+1)*2}s\")\n            break\n    except Exception:\n        pass\n    time.sleep(2)\nelse:\n    raise RuntimeError(\"MLflow server did not start in time — check the process\")"
+   "source": [
+    "import subprocess\n",
+    "import time\n",
+    "import requests as req\n",
+    "\n",
+    "mlflow_process = subprocess.Popen(\n",
+    "    [\"mlflow\", \"server\",\n",
+    "     \"--backend-store-uri\", \"sqlite:///mlflow.db\",\n",
+    "     \"--default-artifact-root\", str(BASE_DIR / \"mlruns\"),\n",
+    "     \"--host\", \"0.0.0.0\",\n",
+    "     \"--port\", \"5000\",\n",
+    "     \"--allowed-hosts\", \"*\",\n",
+    "     \"--cors-allowed-origins\", \"*\"],\n",
+    "    stdout=subprocess.DEVNULL,\n",
+    "    stderr=subprocess.DEVNULL,\n",
+    ")\n",
+    "\n",
+    "# Poll until server responds (MLflow root / returns 200 when ready)\n",
+    "for i in range(20):\n",
+    "    try:\n",
+    "        r = req.get(\"http://localhost:5000/\", timeout=2)\n",
+    "        if r.status_code == 200:\n",
+    "            print(f\"MLflow server ready after {(i+1)*2}s\")\n",
+    "            break\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    time.sleep(2)\n",
+    "else:\n",
+    "    raise RuntimeError(\"MLflow server did not start in time — check the process\")\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -407,7 +438,20 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from evidently.metric_preset import DataDriftPreset\nfrom evidently import Report\nfrom IPython.display import HTML, display\n\n# Evidently requires pandas DataFrames (X_train and drifted_df are both pandas)\nreport = Report(metrics=[DataDriftPreset()])\nreport.run(reference_data=X_train, current_data=drifted_df)\n\n# Save HTML and display inline (get_html is not available in Evidently 0.7.x)\ndrift_html_path = \"/tmp/drift_report.html\"\nreport.save_html(drift_html_path)\ndisplay(HTML(open(drift_html_path).read()))"
+   "source": [
+    "from evidently.presets import DataDriftPreset\n",
+    "from evidently import Report\n",
+    "from IPython.display import HTML, display\n",
+    "\n",
+    "# Evidently requires pandas DataFrames (X_train and drifted_df are both pandas)\n",
+    "report = Report([DataDriftPreset()])\n",
+    "result = report.run(reference_data=X_train, current_data=drifted_df)\n",
+    "\n",
+    "# Save HTML and display inline\n",
+    "drift_html_path = \"/tmp/drift_report.html\"\n",
+    "result.save_html(drift_html_path)\n",
+    "display(HTML(open(drift_html_path).read()))\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -415,7 +459,28 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Log drift report as MLflow artifact\nwith mlflow.start_run(run_name=\"drift_detection\"):\n    mlflow.log_artifact(drift_html_path, \"data_drift\")\n\n# Extract summary from report dict (use .dict() in Evidently 0.7.x)\ndrift_results = report.dict()\ntry:\n    dataset_result = drift_results[\"metrics\"][0][\"result\"]\n    print(f\"\\nDrift summary:\")\n    print(f\"  Dataset drift detected: {dataset_result.get('dataset_drift', 'N/A')}\")\n    print(f\"  Features drifted: {dataset_result.get('number_of_drifted_columns', 'N/A')} / {dataset_result.get('number_of_columns', 'N/A')}\")\nexcept (KeyError, IndexError) as e:\n    print(f\"Could not parse drift summary: {e}\")\n    print(\"See the HTML report above for full results.\")"
+   "source": [
+    "# Log drift report as MLflow artifact\n",
+    "with mlflow.start_run(run_name=\"drift_detection\"):\n",
+    "    mlflow.log_artifact(drift_html_path, \"data_drift\")\n",
+    "\n",
+    "# Extract summary from report dict\n",
+    "drift_results = result.dump_dict()\n",
+    "try:\n",
+    "    mr = drift_results[\"metric_results\"]\n",
+    "    for v in mr.values():\n",
+    "        if \"Count of Drifted\" in v[\"display_name\"]:\n",
+    "            n_drifted = int(v[\"count\"][\"value\"])\n",
+    "            share = v[\"share\"][\"value\"]\n",
+    "            n_total = int(n_drifted / share) if share > 0 else 0\n",
+    "            break\n",
+    "    print(f\"\nDrift summary:\")\n",
+    "    print(f\"  Features drifted: {n_drifted} / {n_total}\")\n",
+    "    print(f\"  Share of drifted columns: {share:.1%}\")\n",
+    "except (KeyError, IndexError, ZeroDivisionError) as e:\n",
+    "    print(f\"Could not parse drift summary: {e}\")\n",
+    "    print(\"See the HTML report above for full results.\")\n"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,13 @@ lab-6 = [
   "tiktoken==0.9.0",
 ]
 lab-7 = [
-  "evidently==0.7.5",
-  "flask==3.1.0",
-  "matplotlib",
-  "mlflow==2.22.0",
+  "evidently==0.7.21",
+  "flask==3.1.3",
+  "matplotlib==3.10.9",
+  "mlflow==3.12.0",
   "numpy==2.4.4",
-  "pandas==3.0.2",
-  "polars==1.30.0",
-  "requests==2.32.3",
+  "pandas==2.3.3",
+  "polars==1.40.1",
+  "requests==2.33.1",
   "scikit-learn==1.8.0",
 ]


### PR DESCRIPTION
Upgrades lab-7 dependencies to resolve the mlflow/pandas conflict and fixes Colab runtime issues discovered during testing.

- Upgrade mlflow 2.22.0 -> 3.12.0 (resolves pandas<3 conflict)
- Downgrade pandas 3.0.2 -> 2.3.3 (required by mlflow)
- Upgrade polars, evidently, flask, requests, matplotlib to versions aligned with mlflow 3.12.0 release window
- Pin matplotlib version (was unpinned)
- Add --allowed-hosts and --cors-allowed-origins flags to mlflow server startup for Colab proxy compatibility
- Fix evidently 0.7.21 API breaking changes: import path, Report constructor, result object methods