### PR TITLE
fix(lab-7): use public URL for mlflow tracking URI

### DIFF
--- a/mlops.ipynb
+++ b/mlops.ipynb
@@ -156,7 +156,16 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import mlflow\n\nmlflow.set_tracking_uri(\"http://localhost:5000\")\n# Verify: list experiments (returns empty list on a fresh server)\nclient = mlflow.MlflowClient()\nexperiments = client.search_experiments()\nprint(f\"MLflow tracking URI: {mlflow.get_tracking_uri()}\")\nprint(f\"Experiments: {len(experiments)} (expected 0 on a fresh server)\")"
+   "source": [
+    "import mlflow\n",
+    "\n",
+    "mlflow.set_tracking_uri(MLFLOW_PUBLIC_URL)\n",
+    "# Verify: list experiments (returns empty list on a fresh server)\n",
+    "client = mlflow.MlflowClient()\n",
+    "experiments = client.search_experiments()\n",
+    "print(f\"MLflow tracking URI: {mlflow.get_tracking_uri()}\")\n",
+    "print(f\"Experiments: {len(experiments)} (expected 0 on a fresh server)\")\n"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Sets mlflow.set_tracking_uri(MLFLOW_PUBLIC_URL) so that all "View run at" messages print the Colab proxy URL students can actually click, instead of http://localhost:5000 which is inaccessible from the browser.